### PR TITLE
Rename coordinates to be `lat` and `lon`

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -18,8 +18,8 @@ def get_npix(dx):
 
 
 def get_extent_mask(dx, extent):
-    lon = dx.longitude
-    lat = dx.latitude
+    lon = dx.lon
+    lat = dx.lat
 
     w, e, s, n = extent  # Shortcut for N/S/E/W bounds
 


### PR DESCRIPTION
In easygems, it is now always implicitly assumed that longitude and latitude are named by their abbreviated form (lat/lon).