### PR TITLE
Add function to create a default GeoAxis

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -101,7 +101,7 @@ def healpix_resample(var, xlims, ylims, nx, ny, src_crs, method="nearest", nest=
     return xr.DataArray(res, coords=[("y", yvals), ("x", xvals)])
 
 
-def create_geoaxis(**subplot_kw):
+def create_geoaxis(add_coastlines=True, **subplot_kw):
     """Convenience function to create a figure with a default map projection."""
     if "projection" not in subplot_kw:
         subplot_kw["projection"] = ccrs.Robinson(central_longitude=-135.58)
@@ -109,12 +109,17 @@ def create_geoaxis(**subplot_kw):
     _, ax = plt.subplots(subplot_kw=subplot_kw)
     ax.set_global()
 
+    if add_coastlines:
+        ax.coastlines(color="#333333", linewidth=plt.rcParams["grid.linewidth"])
+
     return ax
 
 
-def healpix_show(var, dpi=None, ax=None, method="nearest", nest=True, **kwargs):
+def healpix_show(
+    var, dpi=None, ax=None, method="nearest", nest=True, add_coastlines=True, **kwargs
+):
     if ax is None:
-        ax = create_geoaxis()
+        ax = create_geoaxis(add_coastlines=add_coastlines)
     fig = ax.get_figure()
 
     if dpi is not None:
@@ -129,9 +134,11 @@ def healpix_show(var, dpi=None, ax=None, method="nearest", nest=True, **kwargs):
     return ax.imshow(im, extent=xlims + ylims, origin="lower", **kwargs)
 
 
-def healpix_contour(var, dpi=None, ax=None, method="linear", nest=True, **kwargs):
+def healpix_contour(
+    var, dpi=None, ax=None, method="linear", nest=True, add_coastlines=True, **kwargs
+):
     if ax is None:
-        ax = create_geoaxis()
+        ax = create_geoaxis(add_coastlines=add_coastlines)
     fig = ax.get_figure()
 
     if dpi is not None:

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -101,9 +101,20 @@ def healpix_resample(var, xlims, ylims, nx, ny, src_crs, method="nearest", nest=
     return xr.DataArray(res, coords=[("y", yvals), ("x", xvals)])
 
 
+def create_geoaxis(**subplot_kw):
+    """Convenience function to create a figure with a default map projection."""
+    if "projection" not in subplot_kw:
+        subplot_kw["projection"] = ccrs.Robinson(central_longitude=-135.58)
+
+    _, ax = plt.subplots(subplot_kw=subplot_kw)
+    ax.set_global()
+
+    return ax
+
+
 def healpix_show(var, dpi=None, ax=None, method="nearest", nest=True, **kwargs):
     if ax is None:
-        ax = plt.gca()
+        ax = create_geoaxis()
     fig = ax.get_figure()
 
     if dpi is not None:
@@ -120,7 +131,7 @@ def healpix_show(var, dpi=None, ax=None, method="nearest", nest=True, **kwargs):
 
 def healpix_contour(var, dpi=None, ax=None, method="linear", nest=True, **kwargs):
     if ax is None:
-        ax = plt.gca()
+        ax = create_geoaxis()
     fig = ax.get_figure()
 
     if dpi is not None:


### PR DESCRIPTION
When using `healpix_show` or `healpix_contour`, the user has to create a Cartopy `GeoAxis` in the first place. This creates a significant overhead in situations where only a quick view is desired. This PR adds the convenience function `create_geoaxis` which creates a new figure using the Robinson map projection. This function will be used as the new default when users don't explicitly pass an axis.

_PS: One might consider enabling coastlines by default._