### PR TITLE
Replace healpy package with healpix package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ numpy = "*"
 scipy = "*"
 xarray = "*"
 cf_xarray = "*"
-healpy = ">=1.16.3"
+healpix = "*"
 matplotlib = "*"
 cartopy = "*"
 


### PR DESCRIPTION
The PR replaces the healpy backend with the healpix backend.

As a consequence, the bilinear interpolation in `healpix_resample` needed to be refactored. The current interpolation is significantly slower, but interactive usage is feasible.

In my opinion, the decrease in performance is worth the more lightweight dependency and support for Windows users.


This closes #11 