### PR TITLE
Add antialiasing option for `healpix_show`

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -178,7 +178,14 @@ def get_current_geoaxis(**kwargs):
 
 
 def healpix_show(
-    var, dpi=None, ax=None, method="nearest", nest=True, add_coastlines=True, antialias=False, **kwargs
+    var,
+    dpi=None,
+    ax=None,
+    method="nearest",
+    nest=True,
+    add_coastlines=True,
+    antialias=False,
+    **kwargs,
 ):
     if ax is None:
         ax = get_current_geoaxis(add_coastlines=add_coastlines)

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -178,7 +178,7 @@ def get_current_geoaxis(**kwargs):
 
 
 def healpix_show(
-    var, dpi=None, ax=None, method="nearest", nest=True, add_coastlines=True, **kwargs
+    var, dpi=None, ax=None, method="nearest", nest=True, add_coastlines=True, antialias=False, **kwargs
 ):
     if ax is None:
         ax = get_current_geoaxis(add_coastlines=add_coastlines)
@@ -188,6 +188,10 @@ def healpix_show(
         fig.set_dpi(dpi)
 
     _, _, nx, ny = np.array(ax.bbox.bounds, dtype=int)
+
+    if antialias:
+        nx *= 2
+        ny *= 2
 
     xlims = ax.get_xlim()
     ylims = ax.get_ylim()


### PR DESCRIPTION
This PR adds an `antialias` keyword to `healpix_show`.

When enabled, the option will request a nearest-neighbour remapping with an oversampling of 2. The interpolation to the final image can be controlled via the `interpolation` and `interpolation_stage` keywords of `imshow`. The default values (`auto`) actually produce quite decent results, which is why I would not set the parameters at all. If wanted, they can be set manually.

By default `antialias` is set to `False` (should we change that?)