### PR TITLE
Add another possible grid dimension name to function guess_crs().

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -83,6 +83,8 @@ def guess_crs(ds: xr.Dataset):
         pix = ds.cell
     elif "values" in ds.dims:
         pix = ds.values
+    elif "value" in ds.dims:
+        pix = ds.value
 
     crs = xr.DataArray(
         name="crs",


### PR DESCRIPTION
In the IFS simulations for the hackathon, the grid dimension of the HEALPix grid was called `value` and thus couldn't be handled by the function easygems.healpix.guess_crs(), which  only checks for `values` and `cell`. 