### PR TITLE
Separate resampling and plotting routines

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -3,11 +3,10 @@ import warnings
 import numpy as np
 import cf_xarray as cf_xarray
 import xarray as xr
-import matplotlib.pylab as plt
-import cartopy.crs as ccrs
 import healpix
-from cartopy.mpl import geoaxes
-from scipy.interpolate import griddata
+
+from ..resample import HEALPixResampler
+from ..show import map_show, map_contour
 
 
 def get_nest(dx):
@@ -131,139 +130,30 @@ def attach_coords(ds: xr.Dataset, signed_lon=False):
     )
 
 
-def healpix_resample(var, xlims, ylims, nx, ny, src_crs, method="nearest", nest=True):
-    # NOTE: we want the center coordinate of each pixel, thus we have to
-    # compute the linspace over half a pixel size less than the plot's limits
-    dx = (xlims[1] - xlims[0]) / nx
-    dy = (ylims[1] - ylims[0]) / ny
-    xvals = np.linspace(xlims[0] + dx / 2, xlims[1] - dx / 2, nx)
-    yvals = np.linspace(ylims[0] + dy / 2, ylims[1] - dy / 2, ny)
-    xvals2, yvals2 = np.meshgrid(xvals, yvals)
-    latlon = ccrs.PlateCarree().transform_points(
-        src_crs, xvals2, yvals2, np.zeros_like(xvals2)
-    )
-    valid = np.all(np.isfinite(latlon), axis=-1)
-    points = latlon[valid].T
-
-    res = np.full(latlon.shape[:-1], np.nan, dtype=var.dtype)
-
-    if method == "nearest":
-        pix = healpix.ang2pix(
-            get_nside(var),
-            theta=points[0],
-            phi=points[1],
-            nest=nest,
-            lonlat=True,
-        )
-        if var.size < get_npix(var):
-            if not isinstance(var, xr.DataArray):
-                raise ValueError(
-                    "Sparse HEALPix grids are only supported as xr.DataArray"
-                )
-
-            # For xr.DataArrays, selection from sparse HEALPix grids is supported
-            res[valid] = var.sel(cell=pix, method="nearest").where(
-                lambda x: x.cell == pix
-            )
-        else:
-            res[valid] = var[pix]
-    elif method == "linear":
-        lons, lats = healpix.pix2ang(
-            nside=get_nside(var),
-            ipix=np.arange(len(var)),
-            nest=nest,
-            lonlat=True,
-        )
-        lons = (lons + 180) % 360 - 180
-
-        valid_src = ((lons > points[0].min()) & (lons < points[0].max())) | (
-            (lats > points[1].min()) & (lats < points[1].max())
+def healpix_show(var, method=None, nest=True, **kwargs):
+    if method is not None:
+        raise ValueError(
+            "The method keyword is no longer supported.\n"
+            "You can use `easygems.show.map_show()` with a"
+            " custom `easygens.resample.Resampler`."
         )
 
-        res[valid] = griddata(
-            points=np.asarray([lons[valid_src], lats[valid_src]]).T,
-            values=var[valid_src],
-            xi=(points[0], points[1]),
-            method="linear",
-            fill_value=np.nan,
-            rescale=True,
+    r = HEALPixResampler(nside=get_nside(var), nest=nest)
+
+    return map_show(var, resampler=r, **kwargs)
+
+
+def healpix_contour(var, method=None, nest=True, **kwargs):
+    if method is not None:
+        raise ValueError(
+            "The method keyword is no longer supported.\n"
+            "You can use `easygems.show.map_show()` with a"
+            " custom `easygens.resample.Resampler`."
         )
-    else:
-        raise ValueError(f"interpolation method '{method}' not known")
 
-    return xr.DataArray(res, coords=[("y", yvals), ("x", xvals)])
+    r = HEALPixResampler(nside=get_nside(var), nest=nest)
 
-
-def create_geoaxis(add_coastlines=True, **subplot_kw):
-    """Convenience function to create a figure with a default map projection."""
-    if "projection" not in subplot_kw:
-        subplot_kw["projection"] = ccrs.Robinson(central_longitude=-135.58)
-
-    _, ax = plt.subplots(subplot_kw=subplot_kw)
-    ax.set_global()
-
-    if add_coastlines:
-        ax.coastlines(color="#333333", linewidth=plt.rcParams["grid.linewidth"])
-
-    return ax
-
-
-def get_current_geoaxis(**kwargs):
-    """Return current axis, if it is a GeoAxes, otherwise create a new one."""
-    # `plt.gcf().axes` only checks existing axes, while `plt.gca()` also creates one
-    if (ax := plt.gcf().axes) and isinstance(ax[0], geoaxes.GeoAxes):
-        return ax[0]
-    else:
-        return create_geoaxis(**kwargs)
-
-
-def healpix_show(
-    var,
-    dpi=None,
-    ax=None,
-    method="nearest",
-    nest=True,
-    add_coastlines=True,
-    antialias=False,
-    **kwargs,
-):
-    if ax is None:
-        ax = get_current_geoaxis(add_coastlines=add_coastlines)
-    fig = ax.get_figure()
-
-    if dpi is not None:
-        fig.set_dpi(dpi)
-
-    _, _, nx, ny = np.array(ax.bbox.bounds, dtype=int)
-
-    if antialias:
-        nx *= 2
-        ny *= 2
-
-    xlims = ax.get_xlim()
-    ylims = ax.get_ylim()
-    im = healpix_resample(var, xlims, ylims, nx, ny, ax.projection, method, nest)
-
-    return ax.imshow(im, extent=xlims + ylims, origin="lower", **kwargs)
-
-
-def healpix_contour(
-    var, dpi=None, ax=None, method="linear", nest=True, add_coastlines=True, **kwargs
-):
-    if ax is None:
-        ax = get_current_geoaxis(add_coastlines=add_coastlines)
-    fig = ax.get_figure()
-
-    if dpi is not None:
-        fig.set_dpi(dpi)
-
-    _, _, nx, ny = np.array(ax.bbox.bounds, dtype=int)
-
-    xlims = ax.get_xlim()
-    ylims = ax.get_ylim()
-    im = healpix_resample(var, xlims, ylims, nx, ny, ax.projection, method, nest)
-
-    return ax.contour(im.x, im.y, im, **kwargs)
+    return map_contour(var, resampler=r, **kwargs)
 
 
 __all__ = [
@@ -275,9 +165,6 @@ __all__ = [
     "isel_extent",
     "fix_crs",
     "attach_coords",
-    "healpix_resample",
-    "create_geoaxis",
-    "get_current_geoaxis",
     "healpix_show",
     "healpix_contour",
 ]

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -130,28 +130,14 @@ def attach_coords(ds: xr.Dataset, signed_lon=False):
     )
 
 
-def healpix_show(var, method=None, nest=True, **kwargs):
-    if method is not None:
-        raise ValueError(
-            "The method keyword is no longer supported.\n"
-            "You can use `easygems.show.map_show()` with a"
-            " custom `easygens.resample.Resampler`."
-        )
-
-    r = HEALPixResampler(nside=get_nside(var), nest=nest)
+def healpix_show(var, method="nearest", nest=True, **kwargs):
+    r = HEALPixResampler(nside=get_nside(var), nest=nest, method=method)
 
     return map_show(var, resampler=r, **kwargs)
 
 
-def healpix_contour(var, method=None, nest=True, **kwargs):
-    if method is not None:
-        raise ValueError(
-            "The method keyword is no longer supported.\n"
-            "You can use `easygems.show.map_show()` with a"
-            " custom `easygens.resample.Resampler`."
-        )
-
-    r = HEALPixResampler(nside=get_nside(var), nest=nest)
+def healpix_contour(var, method="nearest", nest=True, **kwargs):
+    r = HEALPixResampler(nside=get_nside(var), nest=nest, method=method)
 
     return map_contour(var, resampler=r, **kwargs)
 

--- a/easygems/resample.py
+++ b/easygems/resample.py
@@ -48,6 +48,7 @@ class KDTreeResampler(Resampler):
     """Build a KDTree for lat/lon pairs to find the nearest neighbour."""
 
     def __init__(self, lon, lat):
+        lon = (np.asarray(lon) + 180) % 360 - 180  # Ensure lon [-180, 180]
         self.tree = KDTree(np.array([lon, lat]).T)
 
     def get_values(self, m, coords):
@@ -60,6 +61,7 @@ class DelaunayResampler(Resampler):
     """Perform a Delaunay triangulation to find the neighbouring cells."""
 
     def __init__(self, lon, lat):
+        lon = (np.asarray(lon) + 180) % 360 - 180  # Ensure lon [-180, 180]
         self.tri = Delaunay(np.stack([lon, lat], axis=-1))
 
     def get_values(self, m, coords):

--- a/easygems/resample.py
+++ b/easygems/resample.py
@@ -1,0 +1,77 @@
+import healpix as hp
+import numpy as np
+import xarray as xr
+from scipy.spatial import Delaunay, KDTree
+
+
+class Resampler:
+    def get_values(self, m, coords):
+        """Return value(s) from a map.
+
+        Parameters:
+            m: ndarray, shape (...)
+            coords: ndarray, shape (N, 2)
+
+        Returns:
+            val: ndarray, shape (N)
+        """
+        raise NotImplementedError
+
+
+class HEALPixResampler(Resampler):
+    """Find the nearest cell on an HEALPix grid."""
+
+    def __init__(self, nside, nest=True):
+        self.nside = nside
+        self.nest = nest
+
+    def get_values(self, m, coords):
+        coords = np.asarray(coords)
+
+        idx = hp.ang2pix(
+            nside=self.nside,
+            theta=coords[:, 0],
+            phi=coords[:, 1],
+            nest=self.nest,
+            lonlat=True,
+        )
+
+        if isinstance(m, xr.DataArray):
+            # Using coordinate **values** allows sparse HEALPix grids to be supported.
+            dim = m.dims[0]
+            return m.sel({dim: idx}, method="nearest").where(lambda x: x[dim] == idx)
+        else:
+            return m[idx]
+
+
+class KDTreeResampler(Resampler):
+    """Build a KDTree for lat/lon pairs to find the nearest neighbour."""
+
+    def __init__(self, lon, lat):
+        self.tree = KDTree(np.array([lon, lat]).T)
+
+    def get_values(self, m, coords):
+        _, idx = self.tree.query(coords)
+
+        return np.asarray(m)[idx]
+
+
+class DelaunayResampler(Resampler):
+    """Perform a Delaunay triangulation to find the neighbouring cells."""
+
+    def __init__(self, lon, lat):
+        self.tri = Delaunay(np.stack([lon, lat], axis=-1))
+
+    def get_values(self, m, coords):
+        triangles = self.tri.find_simplex(coords)
+
+        X = self.tri.transform[triangles, :2]
+        Y = coords - self.tri.transform[triangles, 2]
+
+        idx = self.tri.simplices[triangles]
+
+        b = np.einsum("...jk,...k->...j", X, Y)
+        weights = np.concatenate([b, 1 - b.sum(axis=-1)[..., np.newaxis]], axis=-1)
+        valid = triangles >= 0
+
+        return np.where(valid, (np.asarray(m)[idx] * weights).sum(axis=-1), np.nan)

--- a/easygems/show.py
+++ b/easygems/show.py
@@ -1,0 +1,121 @@
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from cartopy.mpl import geoaxes
+
+
+def create_geoaxis(add_coastlines=True, **subplot_kw):
+    """Convenience function to create a figure with a default map projection."""
+    if "projection" not in subplot_kw:
+        subplot_kw["projection"] = ccrs.Robinson(central_longitude=-135.58)
+
+    _, ax = plt.subplots(subplot_kw=subplot_kw)
+    ax.set_global()
+
+    if add_coastlines:
+        ax.coastlines(color="#333333", linewidth=plt.rcParams["grid.linewidth"])
+
+    return ax
+
+
+def get_current_geoaxis(**kwargs):
+    """Return current axis, if it is a GeoAxes, otherwise create a new one."""
+    # `plt.gcf().axes` only checks existing axes, while `plt.gca()` also creates one
+    if (ax := plt.gcf().axes) and isinstance(ax[0], geoaxes.GeoAxes):
+        return ax[0]
+    else:
+        return create_geoaxis(**kwargs)
+
+
+def sample_image(arr, resampler, ax, antialias=False):
+    """Sample an image in pixel-space."""
+    # Get axis size in pixels
+    _, _, nx, ny = np.array(ax.bbox.bounds, dtype=int)
+
+    if antialias:
+        nx *= 2
+        ny *= 2
+
+    # Create 2d-arrays for x/y coordinates in Cartopy coordinates
+    xlims, ylims = ax.get_xlim(), ax.get_ylim()
+
+    dx = (xlims[1] - xlims[0]) / nx
+    dy = (ylims[1] - ylims[0]) / ny
+    xvals, yvals = np.meshgrid(
+        np.linspace(xlims[0] + dx / 2, xlims[1] - dx / 2, nx),
+        np.linspace(ylims[0] + dy / 2, ylims[1] - dy / 2, ny),
+    )
+
+    # Transform to lat/lon coordinates
+    latlon = ccrs.PlateCarree().transform_points(
+        ax.projection, xvals, yvals, np.zeros_like(xvals)
+    )
+    valid = np.all(np.isfinite(latlon), axis=-1)
+
+    # Fill valid points in "plot array"
+    res = np.full(latlon.shape[:-1], np.nan, dtype=arr.dtype)
+    res[valid] = resampler.get_values(arr, latlon[valid, :2])
+
+    return xr.DataArray(res, coords=[("y", yvals[:, 0]), ("x", xvals[0, :])])
+
+
+def map_show(
+    var, resampler, ax=None, antialias=False, dpi=None, add_coastlines=True, **kwargs
+):
+    """Plot a variable on a Cartopy GeoAxes.
+
+    Parameters:
+        var: array-like
+            Variable to plot
+        resampler: Resampler
+            Resampling from lon/lat coordinates to source index
+        ax: cartopy.GeoAxis
+        antialias: bool
+            If True, sample at double the resolution for anti-aliasing
+        dpi: int
+            Pixel resolution of created figure
+        add_coastlines: bool
+            Create GeoAxes with coastlines, if none is passed
+        **kwargs: Additional keyword argument passed to `plt.imshow()`
+    """
+    if ax is None:
+        ax = get_current_geoaxis(add_coastlines=add_coastlines)
+
+    if dpi is not None:
+        ax.get_figure().set_dpi(dpi)
+
+    img = sample_image(var, resampler, ax, antialias)
+    extent = [img.x[0], img.x[-1], img.y[0], img.y[-1]]
+
+    return ax.imshow(img, extent=extent, origin="lower", **kwargs)
+
+
+def map_contour(
+    var, resampler, ax=None, antialias=False, dpi=None, add_coastlines=True, **kwargs
+):
+    """Plot a variable on a Cartopy GeoAxes.
+
+    Parameters:
+        var: array-like
+            Variable to plot
+        resampler: Resampler
+            Resampling from lon/lat coordinates to source index
+        ax: cartopy.GeoAxis
+        antialias: bool
+            If True, sample at double the resolution for anti-aliasing
+        dpi: int
+            Pixel resolution of created figure
+        add_coastlines: bool
+            Create GeoAxes with coastlines, if none is passed
+        **kwargs: Additional keyword argument passed to `plt.imshow()`
+    """
+    if ax is None:
+        ax = get_current_geoaxis(add_coastlines=add_coastlines)
+
+    if dpi is not None:
+        ax.get_figure().set_dpi(dpi)
+
+    img = sample_image(var, resampler, ax, antialias)
+
+    return ax.contour(img.x, img.y, img, **kwargs)

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -46,3 +46,14 @@ def test_kdtree_resampler():
 
     res = r.get_values(val, [[0, 0], [-170, -90]])
     assert np.array_equal(res, np.array([2, 1]))
+
+
+def test_kdtree_resampler_lon_range():
+    lon = [10, 190, 350]
+    lat = [0, 0, 0]
+    val = [1, 2, 3]
+
+    r = resample.KDTreeResampler(lon=lon, lat=lat)
+
+    res = r.get_values(val, [[10, 0], [-170, 0], [-10, 0]])
+    assert np.array_equal(res, np.array([1, 2, 3]))

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -1,6 +1,7 @@
 from easygems import resample
 
 import numpy as np
+import pytest
 import xarray as xr
 
 
@@ -32,6 +33,18 @@ def test_healpix_resampler_sparse():
     r = resample.HEALPixResampler(nside=nside, nest=nest)
 
     assert r.get_values(val, [[0, 0]]) == np.array([4])
+
+
+def test_healpix_resampler_linear():
+    pytest.importorskip("healpy")
+
+    nside = 1
+    nest = True
+    val = np.arange(12)
+
+    r = resample.HEALPixResampler(nside=nside, nest=nest, method="linear")
+
+    assert r.get_values(val, [[45, 0]]) == np.array([4.5])
 
 
 def test_kdtree_resampler():

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -1,0 +1,48 @@
+from easygems import resample
+
+import numpy as np
+import xarray as xr
+
+
+def test_delaunay_resampler():
+    lon = [0, 90, 45]
+    lat = [0, 0, 90]
+    val = [1, 2, 3]
+
+    r = resample.DelaunayResampler(lon=lon, lat=lat)
+
+    assert r.get_values(val, [[45, 45]]) == np.array([2.25])
+
+
+def test_healpix_resampler():
+    nside = 1
+    nest = True
+    val = np.arange(12)
+
+    r = resample.HEALPixResampler(nside=nside, nest=nest)
+
+    assert r.get_values(val, [[0, 0]]) == np.array([4])
+
+
+def test_healpix_resampler_sparse():
+    nside = 1
+    nest = True
+    val = xr.DataArray([3, 4, 5], coords={"cell": [3, 4, 5]})
+
+    r = resample.HEALPixResampler(nside=nside, nest=nest)
+
+    assert r.get_values(val, [[0, 0]]) == np.array([4])
+
+
+def test_kdtree_resampler():
+    lon = [-180, 0, 180]
+    lat = [-90, 0, 90]
+    val = [1, 2, 3]
+
+    r = resample.KDTreeResampler(lon=lon, lat=lat)
+
+    res = r.get_values(val, [[0, 0]])
+    assert np.array_equal(res, np.array([2]))
+
+    res = r.get_values(val, [[0, 0], [-170, -90]])
+    assert np.array_equal(res, np.array([2, 1]))


### PR DESCRIPTION
This PR refactors the HEALPix plotting routines. 
Internally, the code is now clearly separated into a resampling part and a generic map plotting part.

This is done by
* introducing a `resample` submodule that implements a `HEALPixResampler`, `KDTreeResampler`, and a `DelaunayResampler`
* moving and cleaning the code from `healpix_show` and `healpix_contour` into more generic `map_show` and `map_contour` functions which take a `Resampler` alongside a map
* turn `healpix_show` and `healpix_contour` into simple wrapper functions for backwards compatibility 

~~This PR introduces a breaking change by dropping support for the `method` keyword in `healpix_show` and `healpix_contour`. One option to somehow keep it would be to choose the `DelaunayResampler` when `method="linear"` is chosen. However, it seemed cleaner to drop this keyword and point users towards `map_show()` in combination with a resample of their choice.~~

This PR adds a lazy dependence on `healpy`, which is required to run the linear interpolation in the `HEALPixResampler`. 

_The PR introduces a lot of changes, but the commit history is clean and should make the review easier_