### PR TITLE
Reuse existing figure when creating a GeoAxes

### DIFF
--- a/easygems/show.py
+++ b/easygems/show.py
@@ -10,7 +10,10 @@ def create_geoaxis(add_coastlines=True, **subplot_kw):
     if "projection" not in subplot_kw:
         subplot_kw["projection"] = ccrs.Robinson(central_longitude=-135.58)
 
-    _, ax = plt.subplots(subplot_kw=subplot_kw)
+    # The GeoAxes check in get_current_geoaxis() always creates a figure.
+    # Here, we need to ensure that we reuse this figure instead of creating a new one.
+    fig = plt.gcf()
+    ax = fig.add_subplot(111, **subplot_kw)
     ax.set_global()
 
     if add_coastlines:


### PR DESCRIPTION
When using functions like `map_show()` easygems checks for the existence of Cartopy GeoAxes. If no axis is found, a new one with a default projection is created.

In the old implementation, opening a figure would result in the creation of a new figure, as would creating a default axis. This would result in two figures being open. This MR ensures that existing figures are reused when creating a default map.

This closes #39