### PR TITLE
Adjust HEALPix inspection functions to CF Conventions 1.13

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -103,8 +103,8 @@ def guess_crs(ds: xr.Dataset):
         name="crs",
         attrs={
             "grid_mapping_name": "healpix",
-            "healpix_nside": healpix.npix2nside(pix.size),
-            "healpix_order": "nest",
+            "refinement_level": healpix.nside2order(healpix.npix2nside(pix.size)),
+            "indexing_scheme": "nested",
         },
     )
     return ds.assign_coords(crs=crs)

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -118,7 +118,7 @@ def attach_coords(ds: xr.Dataset, signed_lon=False):
     else:
         ds = fix_crs(ds)
 
-    cell = ds.get("cell") if "cell" in ds.dims else np.arange(get_npix(ds))
+    cell = ds.get("cell").values if "cell" in ds.dims else np.arange(get_npix(ds))
 
     lons, lats = healpix.pix2ang(
         get_nside(ds), cell.astype("i8"), nest=get_nest(ds), lonlat=True
@@ -130,7 +130,11 @@ def attach_coords(ds: xr.Dataset, signed_lon=False):
         # While this is mathematically valid, it may be unexpected in Earth system science.
         lons %= 360
     return ds.assign_coords(
-        cell=cell,
+        cell=(
+            ("cell",),
+            cell,
+            {"standard_name": "healpix_index"},
+        ),
         lat=(
             ("cell",),
             lats,

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -24,8 +24,8 @@ def get_nest(dx):
 
 def get_nside(dx):
     try:
-        return dx.cf["grid_mapping"].healpix_nside
-    except (AttributeError, KeyError):
+        grid_mapping = dx.cf["grid_mapping"]
+    except AttributeError:
         if dx.squeeze().ndim > 1:
             raise ValueError(
                 "Cannot infer the HEALPix resolution from a multidimensional dataset.\n"
@@ -34,6 +34,11 @@ def get_nside(dx):
                 "Reference: https://easy.gems.dkrz.de/Processing/datasets/remapping.html#storing-the-coordinate-reference-system"
             )
         return healpix.npix2nside(dx.size)
+    else:
+        try:
+            return healpix.order2nside(grid_mapping.refinement_level)
+        except AttributeError:
+            return grid_mapping.healpix_nside
 
 
 def get_npix(dx):

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -10,7 +10,16 @@ from ..show import map_show, map_contour
 
 
 def get_nest(dx):
-    return dx.cf["grid_mapping"].healpix_order in ["nest", "nested"]
+    try:
+        # Check HEALPix grid parameters compliant with CF Conventions
+        indexing_scheme = dx.cf["grid_mapping"].indexing_scheme
+
+        return indexing_scheme == "nested"
+    except AttributeError:
+        # Check legacy HEALPix grid parameters
+        indexing_scheme = dx.cf["grid_mapping"].healpix_order
+
+        return indexing_scheme in ["nest", "nested"]
 
 
 def get_nside(dx):

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -73,3 +73,7 @@ def test_attach_coords_no_crs():
 def test_get_nside(raw_ds):
     assert get_nside(raw_ds) == 1
     assert get_nside(np.arange(12)) == 1
+
+
+def test_get_nest(raw_ds):
+    assert get_nest(raw_ds)

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -1,14 +1,28 @@
+from itertools import product
+
 import pytest
-from easygems.healpix import attach_coords, get_nside
+from easygems.healpix import attach_coords, get_nest, get_nside
 
 import cf_xarray as cf_xarray
 import numpy as np
 import xarray as xr
 
 
-@pytest.fixture(params=["crs", "healpix"])
+@pytest.fixture(params=product(["crs", "healpix"], ["legacy", "cf"]))
 def raw_ds(request):
-    crs_name = request.param
+    crs_name = request.param[0]
+
+    if request.param[1] == "cf":
+        map_parameters = {
+            "refinement_level": 0,
+            "indexing_scheme": "nested",
+        }
+    elif request.param[1] == "legacy":
+        map_parameters = {
+            "healpix_nside": 1,
+            "healpix_order": "nest",
+        }
+
     return xr.Dataset(
         coords={
             crs_name: (
@@ -16,8 +30,7 @@ def raw_ds(request):
                 [0],
                 {
                     "grid_mapping_name": "healpix",
-                    "healpix_nside": 1,
-                    "healpix_order": "nest",
+                    **map_parameters,
                 },
             )
         }
@@ -54,7 +67,7 @@ def test_attach_coords_no_crs():
     ds = attach_coords(ds)
 
     assert ds.crs
-    assert ds.crs.healpix_nside == 2
+    assert ds.crs.refinement_level == 1
 
 
 def test_get_nside(raw_ds):


### PR DESCRIPTION
This PR updates get HEALPix convenience functions (`get_nest`, `get_nside`, `guess_crs`) to comply with the [grid parameters defined in CF-1.13](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html#healpix).

The functions default to the new conventions but still check for our ad-hoc solution as a fallback.

This closes #42