### PR TITLE
Compute triangulation using 3D convex hull

### DIFF
--- a/easygems/remap.py
+++ b/easygems/remap.py
@@ -1,6 +1,6 @@
 import numpy as np
 import xarray as xr
-from scipy.spatial import Delaunay
+from scipy.spatial import ConvexHull, KDTree
 
 from . import transform
 
@@ -8,9 +8,8 @@ from . import transform
 def compute_weights_delaunay(points, xi):
     """Compute remapping weights for linear interpolation.
 
-    The interpolation is based on a Delaunay triangulation on the sphere [0].
-
-    [0]: https://www.redblobgames.com/x/1842-delaunay-voronoi-sphere/
+    Uses a convex hull of 3D coordinates as a spherical Delaunay triangulation,
+    avoiding all projection artifacts at poles and the dateline.
 
     Args:
         points (tuple[ndarrays]): Tuple with source grid coordinates.
@@ -28,19 +27,20 @@ def compute_weights_delaunay(points, xi):
     See also:
         `apply_weights`
     """
-    # Convert coordinates into stereographic and Cartesian coordinates
-    # for triangulation and weight computation respectively.
-    src_xy = transform.latlon2stereographic(np.array(points).T)
+    # Convert coordinates into Cartesian coordinates
+    # for triangulation and weight computation.
     src_xyz = transform.latlon2xyz(np.array(points).T)
-
-    tgt_xy = transform.latlon2stereographic(np.stack(xi, axis=-1))
     tgt_xyz = transform.latlon2xyz(np.stack(xi, axis=-1))
 
-    # Triangulation in stereographic projection
-    tri = Delaunay(src_xy)
-    triangles = tri.find_simplex(tgt_xy)
-    src_idx = tri.simplices[triangles]
-    valid = triangles >= 0
+    simplices = ConvexHull(src_xyz).simplices
+
+    centroids = src_xyz[simplices].mean(axis=1)
+    centroids /= np.linalg.norm(centroids, axis=1, keepdims=True)
+    centroid_tree = KDTree(centroids)
+
+    tgt_xyz /= np.linalg.norm(tgt_xyz, axis=1, keepdims=True)
+    _, cidx = centroid_tree.query(tgt_xyz)
+    src_idx = simplices[cidx]
 
     # Compute barycentric weights in 3D
     verts_xyz = src_xyz[src_idx]
@@ -58,7 +58,7 @@ def compute_weights_delaunay(points, xi):
         data_vars={
             "src_idx": (("tgt_idx", "tri"), src_idx),
             "weights": (("tgt_idx", "tri"), weights),
-            "valid": (("tgt_idx",), valid),
+            "valid": (("tgt_idx",), np.full(cidx.size, fill_value=True)),
         }
     )
 

--- a/easygems/resample.py
+++ b/easygems/resample.py
@@ -1,7 +1,7 @@
 import healpix as hp
 import numpy as np
 import xarray as xr
-from scipy.spatial import Delaunay, KDTree
+from scipy.spatial import ConvexHull, KDTree
 
 from . import transform
 
@@ -105,26 +105,31 @@ class KDTreeResampler(Resampler):
 class DelaunayResampler(Resampler):
     """Perform a Delaunay triangulation to find the neighbouring cells.
 
-    References:
-        https://www.redblobgames.com/x/1842-delaunay-voronoi-sphere/
+    Uses a convex hull of 3D coordinates as a spherical Delaunay triangulation,
+    avoiding all projection artifacts at poles and the dateline.
     """
 
     def __init__(self, lon, lat):
-        xy = transform.latlon2stereographic(np.array([lon, lat]).T)
-
         self.xyz = transform.latlon2xyz(np.array([lon, lat]).T)
-        self.tri = Delaunay(xy)
+        self.simplices = ConvexHull(self.xyz).simplices
+
+        centroids = self.xyz[self.simplices].mean(axis=1)
+        centroids /= np.linalg.norm(centroids, axis=1, keepdims=True)
+
+        self.centroid_tree = KDTree(centroids)
+
+    def find_simplex(self, xyz):
+        _, cidx = self.centroid_tree.query(xyz)
+        return self.simplices[cidx]
 
     def get_values(self, m, coords):
         coords = np.asarray(coords)
         m = np.asarray(m)
 
-        # Triangulation in stereographic projection
-        xy = transform.latlon2stereographic(coords)
-        triangles = self.tri.find_simplex(xy)
-        valid = triangles >= 0
+        xyz = transform.latlon2xyz(coords)
+        xyz /= np.linalg.norm(xyz, axis=1, keepdims=True)
 
-        idx = self.tri.simplices[triangles]
+        idx = self.find_simplex(xyz)
 
         # Compute barycentric weights in 3D
         verts_xyz = self.xyz[idx]
@@ -138,4 +143,4 @@ class DelaunayResampler(Resampler):
 
         weights = np.stack([w0, w1, w2], axis=-1)
 
-        return np.where(valid, (m[idx] * weights).sum(axis=-1), np.nan)
+        return (m[idx] * weights).sum(axis=-1)

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -6,9 +6,9 @@ import xarray as xr
 
 
 def test_delaunay_resampler():
-    lon = [0, 90, 45]
-    lat = [0, 0, 90]
-    val = [1, 2, 3]
+    lon = [0, 90, 45, 180]
+    lat = [0, 0, 90, 0]
+    val = [1, 2, 3, 4]
 
     r = resample.DelaunayResampler(lon=lon, lat=lat)
 


### PR DESCRIPTION
This PR changes the triangulation methods used to compute remapping weights (and resampling).

The old implementation used a 2D Delaunay triangulation in stereographic projection. While this solved problems at the dateline, the South Pole was "ripped apart".

The new implementation computes the 3D convex hull on the 3D cartesian coordinates directly. This solves all remapping artefacts, e.g. dateline and both poles.

This closes #41, closes #48 

_PS.: Surprisingly, in my tests, the new implementation is also significantly faster_