### PR TITLE
Refactor inspection of HEALPix indexing scheme

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -10,6 +10,15 @@ from ..show import map_show, map_contour
 
 
 def get_nest(dx):
+    warnings.warn(
+        "This function is deprecated. Use `is_nested()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return is_nested(dx)
+
+
+def is_nested(dx):
     try:
         # Check HEALPix grid parameters compliant with CF Conventions
         indexing_scheme = dx.cf["grid_mapping"].indexing_scheme
@@ -111,7 +120,7 @@ def fix_crs(ds: xr.Dataset):
                     # https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html#healpix
                     "grid_mapping_name": "healpix",
                     "refinement_level": healpix.nside2order(get_nside(ds)),
-                    "indexing_scheme": "nested" if get_nest(ds) else "ring",
+                    "indexing_scheme": "nested" if is_nested(ds) else "ring",
                 },
             )
         }
@@ -149,7 +158,7 @@ def attach_coords(ds: xr.Dataset, signed_lon=False):
     cell = ds.get("cell").values if "cell" in ds.dims else np.arange(get_npix(ds))
 
     lons, lats = healpix.pix2ang(
-        get_nside(ds), cell.astype("i8"), nest=get_nest(ds), lonlat=True
+        get_nside(ds), cell.astype("i8"), nest=is_nested(ds), lonlat=True
     )
     if signed_lon:
         lons = np.where(lons <= 180, lons, lons - 360)
@@ -189,7 +198,7 @@ def healpix_contour(var, method="nearest", nest=True, **kwargs):
 
 
 __all__ = [
-    "get_nest",
+    "is_nested",
     "get_nside",
     "get_npix",
     "get_extent_mask",

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -14,6 +14,13 @@ def get_nest(dx):
         # Check HEALPix grid parameters compliant with CF Conventions
         indexing_scheme = dx.cf["grid_mapping"].indexing_scheme
 
+        valid_parameters = ("nested", "ring", "nuniq", "zuniq")
+        if indexing_scheme not in valid_parameters:
+            raise ValueError(
+                f"Indexing scheme '{indexing_scheme}' is not in the list of valid parameters: {valid_parameters}\n"
+                "Further details: https://cfconventions.org/cf-conventions/cf-conventions.html#healpix"
+            )
+
         return indexing_scheme == "nested"
     except AttributeError:
         # Check legacy HEALPix grid parameters

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -74,7 +74,8 @@ def test_attach_coords_adds_cell(raw_ds):
 def test_attach_coords_no_crs():
     ds = xr.Dataset(coords={"cell": np.arange(48)})
 
-    ds = attach_coords(ds)
+    with pytest.warns():
+        ds = attach_coords(ds)
 
     assert ds.crs
     assert ds.crs.refinement_level == 1

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -1,7 +1,7 @@
 from itertools import product
 
 import pytest
-from easygems.healpix import attach_coords, get_index, get_nest, get_nside
+from easygems.healpix import attach_coords, get_index, get_nest, is_nested, get_nside
 
 import cf_xarray as cf_xarray
 import numpy as np
@@ -96,7 +96,12 @@ def test_get_nside_dataarray(ds):
 
 
 def test_get_nest(raw_ds):
-    assert get_nest(raw_ds)
+    with pytest.warns(DeprecationWarning):
+        assert get_nest(raw_ds)
+
+
+def test_is_nested(raw_ds):
+    assert is_nested(raw_ds)
 
 
 @pytest.mark.parametrize("known_name", ["cell", "value", "values"])
@@ -142,4 +147,4 @@ def test_invalid_crs():
     )
 
     with pytest.raises(ValueError):
-        get_nest(ds)
+        is_nested(ds)

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -120,3 +120,26 @@ def test_get_index_bycf(raw_ds):
     )
 
     assert np.array_equal(get_index(ds), ds["unknown_name"].values)
+
+
+def test_invalid_crs():
+    """Test handling of CRS information with mixed conventions.
+
+    We should explicitly fail in cases
+    where the attribute names adhere to CF conventions,
+    but the values do not.
+    """
+    ds = xr.Dataset(
+        coords={
+            "crs": xr.DataArray(
+                attrs={
+                    "grid_mapping_name": "healpix",
+                    "refinement_level": 0,
+                    "indexing_scheme": "nest",
+                },
+            )
+        }
+    )
+
+    with pytest.raises(ValueError):
+        get_nest(ds)


### PR DESCRIPTION
This PR:
* checks if the provided HEALPix indexing scheme is in the controlled vocabulary defined in the CF Conventions
* renames the `get_nest()` function to `is_nested()` for clarity; the old function is kept for backwards compatibility but a `DeprecationWarning` is emitted


There is still the open question of what to do about nside parameters that are wrongly assigned to the `refinement_level`.  
One option is to emit a user warning if the refinement level is above 12 or something. This is at least a strong evidence that we are dealing with a mislabeling 🤷 
