### PR TITLE
Refactor `healpix.get_index()`

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -62,17 +62,28 @@ def get_npix(dx):
     return healpix.nside2npix(get_nside(dx))
 
 
-def get_index(dx, dtype=np.int64):
-    """Return the (most likely to be) HEALPix index values."""
-    for c in dx.coords.values():
-        if c.attrs.get("standard_name") == "healpix_index":
-            index = c.values
+def get_index_name(dx):
+    """Return the name of the (most likely) HEALPix index."""
+    for name, coord in dx.coords.items():
+        if coord.attrs.get("standard_name") == "healpix_index":
+            return name
 
     for possible_index in ("cell", "value", "values"):
         if possible_index in dx.dims:
-            index = dx[possible_index].values
+            return possible_index
 
-    return index.astype(dtype)
+    raise KeyError("Could not find HEALPix index.")
+
+
+def get_index(dx, dtype=np.int64):
+    """Return the (most likely) HEALPix index."""
+    healpix_index = get_index_name(dx)
+    return xr.DataArray(
+        name=healpix_index,
+        dims=(healpix_index,),
+        data=dx[healpix_index].values.astype(dtype),
+        attrs={"standard_name": "healpix_index"},
+    )
 
 
 def get_extent_mask(dx, extent):

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -62,17 +62,17 @@ def get_npix(dx):
     return healpix.nside2npix(get_nside(dx))
 
 
-def get_index(dx):
+def get_index(dx, dtype=np.int64):
+    """Return the (most likely to be) HEALPix index values."""
     for c in dx.coords.values():
         if c.attrs.get("standard_name") == "healpix_index":
-            return c.values
+            index = c.values
 
-    if "cell" in dx.dims:
-        return dx.cell.values
-    elif "values" in dx.dims:
-        return dx["values"].values
-    elif "value" in dx.dims:
-        return dx.value.values
+    for possible_index in ("cell", "value", "values"):
+        if possible_index in dx.dims:
+            index = dx[possible_index].values
+
+    return index.astype(dtype)
 
 
 def get_extent_mask(dx, extent):

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -210,6 +210,8 @@ def healpix_contour(var, method="nearest", nest=True, **kwargs):
 
 __all__ = [
     "is_nested",
+    "get_index",
+    "get_index_name",
     "get_nside",
     "get_npix",
     "get_extent_mask",

--- a/tests/test_healpix_coords.py
+++ b/tests/test_healpix_coords.py
@@ -111,6 +111,7 @@ def test_get_index_byname(raw_ds, known_name):
     ds = raw_ds.assign_coords({known_name: np.arange(12)})
 
     assert np.array_equal(get_index(ds), ds[known_name].values)
+    assert get_index(ds).dtype == np.int64
 
 
 def test_get_index_bycf(raw_ds):
@@ -126,6 +127,7 @@ def test_get_index_bycf(raw_ds):
     )
 
     assert np.array_equal(get_index(ds), ds["unknown_name"].values)
+    assert get_index(ds).dtype == np.int64
 
 
 def test_invalid_crs():


### PR DESCRIPTION
This functions reactor the HEALPix `get_index()` function:
* introduce a separate `get_index_name()` function for finding the index (CF Convention has precedence)
* return the index values as `xr.DataArray` with it's name attached
* ensure that the index is returned as `np.int64`