### PR TITLE
Revise handling of helper function to sample HEALPix maps

### DIFF
--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -4,6 +4,7 @@ import numpy as np
 import cf_xarray as cf_xarray
 import xarray as xr
 import healpix
+import pyproj
 
 from ..resample import HEALPixResampler
 from ..show import map_show, map_contour
@@ -108,6 +109,34 @@ def get_index_extent(dx, extent):
 def select_extent(dx, extent):
     """Return a subselected HEALPix dataset within a geospatial extent."""
     idx = get_index_extent(dx, extent)
+
+    return dx.sel({idx.name: idx})
+
+
+def get_index_section(dx, lon1, lat1, lon2, lat2, nsample=3600):
+    """Return indices of all HEALPix cells along a geospatial section."""
+    healpix_index = get_index(dx)
+
+    coords = np.array(pyproj.Geod(ellps="WGS84").npts(lon1, lat1, lon2, lat2, nsample))
+    section_indices = healpix.ang2pix(
+        get_nside(dx),
+        coords[:, 0],
+        coords[:, 1],
+        nest=is_nested(dx),
+        lonlat=True,
+    )
+    section_indices = np.unique(section_indices)
+
+    is_on_section = healpix_index.isin(section_indices)
+
+    return healpix_index.where(is_on_section.compute(), drop=True).astype(
+        healpix_index.dtype
+    )
+
+
+def select_section(dx, lon1, lat1, lon2, lat2, **kwargs):
+    """Return indices of all HEALPix cells along a geospatial section."""
+    idx = get_index_section(dx, lon1, lat1, lon2, lat2, **kwargs)
 
     return dx.sel({idx.name: idx})
 
@@ -224,6 +253,8 @@ __all__ = [
     "get_index_name",
     "get_index_extent",
     "select_extent",
+    "get_index_section",
+    "select_section",
     "get_nside",
     "get_npix",
     "get_full_chunks",

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -86,16 +86,30 @@ def get_index(dx, dtype=np.int64):
     )
 
 
-def get_extent_mask(dx, extent):
+def get_index_extent(dx, extent):
+    """Return indices of all HEALPix cells within a geospatial extent."""
+    healpix_index = get_index(dx)
+
+    # Get coordinates and N/S/E/W bounds
     lon = dx.lon
     lat = dx.lat
+    w, e, s, n = extent
 
-    w, e, s, n = extent  # Shortcut for N/S/E/W bounds
-
+    # Compute boolean mask
     is_in_lon = (lon - w) % 360 < (e - w) % 360  # consider sign change
     is_in_lat = (lat > s) & (lat < n)
+    is_in_extent = is_in_lon & is_in_lat
 
-    return is_in_lon & is_in_lat
+    return healpix_index.where(is_in_extent.compute(), drop=True).astype(
+        healpix_index.dtype
+    )
+
+
+def select_extent(dx, extent):
+    """Return a subselected HEALPix dataset within a geospatial extent."""
+    idx = get_index_extent(dx, extent)
+
+    return dx.sel({idx.name: idx})
 
 
 def get_full_chunks(indices, chunksize):
@@ -103,10 +117,6 @@ def get_full_chunks(indices, chunksize):
     used_chunks = np.unique(np.asarray(indices) // chunksize)
 
     return (used_chunks[:, np.newaxis] * chunksize + np.arange(chunksize)).flatten()
-
-
-def isel_extent(dx, extent):
-    return np.arange(get_npix(dx))[get_extent_mask(dx, extent)]
 
 
 def broadcast_array(dx, fill_value=np.nan):
@@ -212,11 +222,11 @@ __all__ = [
     "is_nested",
     "get_index",
     "get_index_name",
+    "get_index_extent",
+    "select_extent",
     "get_nside",
     "get_npix",
-    "get_extent_mask",
     "get_full_chunks",
-    "isel_extent",
     "fix_crs",
     "attach_coords",
     "healpix_show",

--- a/easygems/healpix/__init__.py
+++ b/easygems/healpix/__init__.py
@@ -5,6 +5,7 @@ import cf_xarray as cf_xarray
 import xarray as xr
 import healpix
 import pyproj
+import regionmask
 
 from ..resample import HEALPixResampler
 from ..show import map_show, map_contour
@@ -141,6 +142,44 @@ def select_section(dx, lon1, lat1, lon2, lat2, **kwargs):
     return dx.sel({idx.name: idx})
 
 
+def get_index_regionmask(dx, region, defined_regions=None):
+    """Return the HEALPix indices inside a defined region.
+
+    Note:
+        Any defined region following the `regionmask` specification can be used.
+        The AR6 SREX region(s) are the default.
+
+    Reference:
+        https://regionmask.readthedocs.io/en/stable/defined_scientific.html
+    """
+    if "lon" not in dx.variables and "lat" not in dx.variables:
+        raise AttributeError("Could not find 'lat' and 'lon' variables.")
+
+    if defined_regions is None:
+        defined_regions = regionmask.defined_regions.ar6.all
+
+    is_in_region = defined_regions.mask(dx.lon, dx.lat).isin(
+        defined_regions.map_keys(region)
+    )
+
+    return get_index(dx)[is_in_region]
+
+
+def select_regionmask(dx, region, defined_regions=None):
+    """Return a subselected HEALPix dataset inside a given AR6 SREX region(s).
+
+    Note:
+        Any defined region following the `regionmask` specification can be used.
+        The AR6 SREX region(s) are the default.
+
+    Reference:
+        https://regionmask.readthedocs.io/en/stable/defined_scientific.html
+    """
+    idx = get_index_regionmask(dx, region, defined_regions=defined_regions)
+
+    return dx.sel({idx.name: idx})
+
+
 def get_full_chunks(indices, chunksize):
     """Return indices of complete chunks, given a list of indices and a chunksize."""
     used_chunks = np.unique(np.asarray(indices) // chunksize)
@@ -255,6 +294,8 @@ __all__ = [
     "select_extent",
     "get_index_section",
     "select_section",
+    "get_index_regionmask",
+    "select_regionmask",
     "get_nside",
     "get_npix",
     "get_full_chunks",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ healpy = { version = "*", markers = "sys_platform != 'win32'" }
 matplotlib = "*"
 cartopy = "*"
 pyproj = "*"
+regionmask = ">=0.13.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ healpix = "*"
 healpy = { version = "*", markers = "sys_platform != 'win32'" }
 matplotlib = "*"
 cartopy = "*"
+pyproj = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
This PR revises the subselection of HEALPix datasets signifcantly.

The new convention is that selection consists of function pairs called `get_index_XXX()` which returns an Xarray data array with corresponding global HEALPix indices, and `select_XXX()` which returns a subselected Xarray dataset.

* The function `isel_extent()` and `get_extent_mask()` are renamed to `get_index_extent()` and `select_extent()` respectively.
* Add new pair of functions `get_index_section()` and `select_section()`
* Add new pair of functions `get_index_regionmask()` and `select_regionmask()`
* Adds `pyproj` and `regionmask` as installation dependencies