### PR TITLE
Add function to plot the difference between maps

### DIFF
--- a/easygems/show.py
+++ b/easygems/show.py
@@ -97,6 +97,53 @@ def map_show(
     return ax.imshow(img, extent=extent, origin="lower", **kwargs)
 
 
+def map_diff(
+    var_a,
+    resampler_a,
+    var_b,
+    resampler_b,
+    ax=None,
+    antialias=False,
+    dpi=None,
+    add_coastlines=True,
+    **kwargs,
+):
+    """Plot the difference between two fields on a Cartopy GeoAxes.
+
+    Parameters:
+        var_a: array-like
+            Minuend
+        resampler_a: Resampler
+            Resampling from lon/lat coordinates to source index for var_a
+        var_b: array-like
+            Subtrahend
+        resampler_b: Resampler
+            Resampling from lon/lat coordinates to source index for var_b
+        ax: cartopy.GeoAxis
+        antialias: bool
+            If True, sample at double the resolution for anti-aliasing
+        dpi: int
+            Pixel resolution of created figure
+        add_coastlines: bool
+            Create GeoAxes with coastlines, if none is passed
+        **kwargs: Additional keyword argument passed to `plt.imshow()`
+    """
+    if ax is None:
+        ax = get_current_geoaxis(add_coastlines=add_coastlines)
+
+    if dpi is not None:
+        ax.get_figure().set_dpi(dpi)
+
+    img_a = sample_image(var_a, resampler_a, ax, antialias)
+    img_b = sample_image(var_b, resampler_b, ax, antialias)
+
+    # Use the original map extent, as the x and y coordinates in img
+    # are shifted by half a pixel to create middle points.
+    extent = ax.get_xlim() + ax.get_ylim()
+
+    return ax.imshow(img_a - img_b, extent=extent, origin="lower", **kwargs)
+
+
 def map_contour(
     var, resampler, ax=None, antialias=False, dpi=None, add_coastlines=True, **kwargs
 ):


### PR DESCRIPTION
This PR adds the function `map_diff()`, which takes two fields and their respective resamplers to plot the difference between the fields.

For example, one can visualise the difference between data on HEALPix and the ICON native grid directly:

```python
import intake

from easygems import healpix, resample, show


cat = intake.open_catalog("https://data.nextgems-h2020.eu/online.yaml")

icon = cat.tutorial["ICON.native.2d_P1D_mean"](chunks={}).to_dask()
era5 = cat.ERA5(zoom=8).to_dask()

show.map_diff(
    icon["ts"].mean("time"),
    resample.KDTreeResampler(icon.lon, icon.lat),
    era5["2t"].sel(time="2020-01").mean("time"),
    resample.HEALPixResampler(nside=healpix.get_nside(era5)),
    vmin=-10,
    vmax=10,
    cmap="twilight_shifted",
)
```

<img width="516" alt="map_diff_icon_era5" src="https://github.com/user-attachments/assets/59ce11cd-1be5-4fff-8e44-473ce8e820bc" />


